### PR TITLE
Move `dotenv` from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "jade": "^1.11.0",
-    "pb-node": "^2.0.1"
+    "pb-node": "^2.0.1",
+    "dotenv": "^2.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
@@ -19,7 +20,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "dotenv": "^2.0.0",
     "jquery": "^2.2.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",


### PR DESCRIPTION
to avoid Node throwing "Cannot find module 'dotenv'" error when deployed to Elastic Beanstalk.